### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/R/CommonFormatFuns.R
+++ b/R/CommonFormatFuns.R
@@ -363,12 +363,12 @@ GetFormatFunctions <- function(docstyle = "text", DateFormatter){
     fmtISRN <- label(prefix = 'ISRN: ', suffix = '.')
     fmtDOI <- switch(docstyle, html = function(doi){
                             if (length(doi)){
-                              paste0("DOI: \\href{http://dx.doi.org/",
+                              paste0("DOI: \\href{https://doi.org/",
                                      doi, "}{", doi, "}.")
                             }
                           }, markdown = function(doi){
                               if (length(doi)){
-                                paste0("DOI: [", doi, "](http://dx.doi.org/",
+                                paste0("DOI: [", doi, "](https://doi.org/",
                                        doi, ").")
                               }
                             }, label(prefix = 'DOI: ', suffix = '.'))

--- a/R/GetBibEntryWithDOI.R
+++ b/R/GetBibEntryWithDOI.R
@@ -10,7 +10,7 @@
 #' @return an object of class BibEntry.
 #' @export
 #' @details
-#' The bibliographic information returned by the search of the \url{http://dx.doi.org}
+#' The bibliographic information returned by the search of the \url{https://doi.org}
 #' API is temporarily
 #' written to a file and then read back into \code{R} and return as a
 #' \code{BibEntry} object.
@@ -19,7 +19,7 @@
 #' @importFrom utils URLdecode
 #' @seealso \code{\link{ReadCrossRef}}, \code{\link{BibEntry}}
 #' @examples
-#' if (interactive() && !httr::http_error("http://dx.doi.org/"))
+#' if (interactive() && !httr::http_error("https://doi.org/"))
 #'   GetBibEntryWithDOI(c("10.1016/j.iheduc.2003.11.004", "10.3998/3336451.0004.203"))
 GetBibEntryWithDOI <- function(doi, temp.file=tempfile(fileext = '.bib'),
                                delete.file = TRUE){
@@ -27,7 +27,7 @@ GetBibEntryWithDOI <- function(doi, temp.file=tempfile(fileext = '.bib'),
   on.exit(if (delete.file && file.exists(temp.file)) file.remove(temp.file))
   successes <- logical(length(doi))
   for (i in seq_along(doi)){
-    temp <- GET(modify_url('http://dx.doi.org/', path = doi[i]),
+    temp <- GET(modify_url('https://doi.org/', path = doi[i]),
                     config = list(followlocation = TRUE),
                       add_headers(Accept = "application/x-bibtex"))
     if (!http_error(temp)){

--- a/R/GetDOIs.R
+++ b/R/GetDOIs.R
@@ -50,7 +50,7 @@ GetDOIs <- function(bib){
         match.str <- paste0(missing.dois.pos[matches], collapse = ", ")
         message(gettextf("Matches for entries at positions %s.",
                        match.str))
-        bib$doi[missing.dois.pos[matches]] <- sub("http://dx.doi.org/", "",
+        bib$doi[missing.dois.pos[matches]] <- sub("https://doi.org/", "",
                                                   vapply(json.res[[1L]], "[[",
                                                          "",
                                                          "doi")[matches],

--- a/R/GetDOIs.R
+++ b/R/GetDOIs.R
@@ -50,7 +50,7 @@ GetDOIs <- function(bib){
         match.str <- paste0(missing.dois.pos[matches], collapse = ", ")
         message(gettextf("Matches for entries at positions %s.",
                        match.str))
-        bib$doi[missing.dois.pos[matches]] <- sub("https://doi.org/", "",
+        bib$doi[missing.dois.pos[matches]] <- sub("https?://(dx\\.)?doi.org/", "",
                                                   vapply(json.res[[1L]], "[[",
                                                          "",
                                                          "doi")[matches],

--- a/R/ReadCrossRef.R
+++ b/R/ReadCrossRef.R
@@ -101,7 +101,7 @@ ReadCrossRef <- function(query = "", filter = list(), limit = 5, offset = 0,
   ## if query is valid doi, skip search and get BibTeX entry right away
   if (nzchar(.doi <- SearchDOIText(query))){
     num.res <- 1
-    bad <- GetCrossRefBibTeX(paste0("http://dx.doi.org/", .doi), temp.file)
+    bad <- GetCrossRefBibTeX(paste0("https://doi.org/", .doi), temp.file)
   }else{
     if (use.old.api){
       if (.is_not_nonempty_text(query))
@@ -176,7 +176,7 @@ ReadCrossRef <- function(query = "", filter = list(), limit = 5, offset = 0,
         for(i in 1:num.res){
           if (fromj[[i]][[score.str]] >= min.relevance){
               bad <- bad + GetCrossRefBibTeX(paste0(if (!use.old.api)
-                                                        "http://dx.doi.org/",
+                                                        "https://doi.org/",
                                                     fromj[[i]][[doi.str]]),
                                              temp.file)
               if (verbose)

--- a/R/open.BibEntry.R
+++ b/R/open.BibEntry.R
@@ -72,7 +72,7 @@ GetURL <- function(entry, flds, to.bib = FALSE){
         }
       }
     }else if (flds[i] == "doi" && !is.null(entry[["doi"]])){
-      url <- paste0("http://dx.doi.org/", entry[["doi"]])
+      url <- paste0("https://doi.org/", entry[["doi"]])
       opened <- TRUE
     }else if (flds[i] == "url" && !is.null(entry[["url"]])){
       url <- entry[["url"]]

--- a/man/GetBibEntryWithDOI.Rd
+++ b/man/GetBibEntryWithDOI.Rd
@@ -23,13 +23,13 @@ an object of class BibEntry.
 Uses the DOI System API to look up bibliography information given a set of DOIs.
 }
 \details{
-The bibliographic information returned by the search of the \url{http://dx.doi.org}
+The bibliographic information returned by the search of the \url{https://doi.org}
 API is temporarily
 written to a file and then read back into \code{R} and return as a
 \code{BibEntry} object.
 }
 \examples{
-if (interactive() && !httr::http_error("http://dx.doi.org/"))
+if (interactive() && !httr::http_error("https://doi.org/"))
   GetBibEntryWithDOI(c("10.1016/j.iheduc.2003.11.004", "10.3998/3336451.0004.203"))
 }
 \references{

--- a/tests/testthat/test-crossref.R
+++ b/tests/testthat/test-crossref.R
@@ -6,7 +6,7 @@ context("Crossref")
 
 test_that("GetBibEntryWithDOIs retrieves DOIs", {
     skip_on_cran()
-    if (httr::http_error("http://dx.doi.org/"))
+    if (httr::http_error("https://doi.org/"))
         skip("Couldn't connect to dx.doi.org")
 
     dois <- c("10.1016/j.iheduc.2003.11.004", "10.3998/3336451.0004.203")
@@ -19,7 +19,7 @@ test_that("GetBibEntryWithDOIs retrieves DOIs", {
 
 test_that("GetBibEntryWithDOIs continues if some DOIs not found", {
     skip_on_cran()
-    if (httr::http_error("http://dx.doi.org/"))
+    if (httr::http_error("https://doi.org/"))
         skip("Couldn't connect to dx.doi.org")
 
     dois <- c("NotADOI", "10.3998/3336451.0004.203")

--- a/tests/testthat/test-crossref.R
+++ b/tests/testthat/test-crossref.R
@@ -7,7 +7,7 @@ context("Crossref")
 test_that("GetBibEntryWithDOIs retrieves DOIs", {
     skip_on_cran()
     if (httr::http_error("https://doi.org/"))
-        skip("Couldn't connect to dx.doi.org")
+        skip("Couldn't connect to doi.org")
 
     dois <- c("10.1016/j.iheduc.2003.11.004", "10.3998/3336451.0004.203")
     out <- GetBibEntryWithDOI(dois)
@@ -20,7 +20,7 @@ test_that("GetBibEntryWithDOIs retrieves DOIs", {
 test_that("GetBibEntryWithDOIs continues if some DOIs not found", {
     skip_on_cran()
     if (httr::http_error("https://doi.org/"))
-        skip("Couldn't connect to dx.doi.org")
+        skip("Couldn't connect to doi.org")
 
     dois <- c("NotADOI", "10.3998/3336451.0004.203")
     out <- GetBibEntryWithDOI(dois)


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating the code that generates new DOI links.

Cheers :-)