### PR TITLE
[WIP] Add 'type' arg in BibLatexAuthorYear thesis and report parsers

### DIFF
--- a/R/07makeBibLatexAuthoryear.R
+++ b/R/07makeBibLatexAuthoryear.R
@@ -717,7 +717,7 @@ MakeAuthorYear <- function(docstyle = "text"){
       }
     }
 
-    formatReport <- function(paper){
+    formatReport <- function(paper, type = NULL){
         collapse(c(fmtBAuthor(paper), fmtDate(attr(paper, 'dateobj'),
                                               paper$.index),
                    fmtBTitle(paper$title, paper$subtitle),
@@ -735,7 +735,7 @@ MakeAuthorYear <- function(docstyle = "text"){
                ))    
     }
 
-    formatThesis <- function(paper){
+    formatThesis <- function(paper, type = NULL){
         collapse(c(fmtBAuthor(paper), fmtDate(attr(paper, 'dateobj'),
                                               paper$.index), 
                    fmtIBTitle(paper$title, paper$subtitle, FALSE),


### PR DESCRIPTION
`toRd.BibEntry()` calls `formatReport()` and `formatThesis()` with 2 args for `"techreport"`, ` "phdthesis"` and `"mathesis"` `paper$type`s as shown below:

https://github.com/ropensci/RefManageR/blob/0e123f9c33ea9787919799fdcacd4a2f2467c4d1/R/toRd.R#L83-L100

However, `formatReport()` and `formatThesis()` only accept one argument when called by `MakeAuthorYear()`:

https://github.com/ropensci/RefManageR/blob/0e123f9c33ea9787919799fdcacd4a2f2467c4d1/R/07makeBibLatexAuthoryear.R#L720

https://github.com/ropensci/RefManageR/blob/0e123f9c33ea9787919799fdcacd4a2f2467c4d1/R/07makeBibLatexAuthoryear.R#L738

This causes an issue when you have a bibliography with either `"techreport"`, ` "phdthesis"` and `"mathesis"` types and use the `authoryear` style.

This is not the case with default format because `formatReport()` and `formatThesis()` are defined with two arguments in `MakeBibLaTeX()`:

https://github.com/ropensci/RefManageR/blob/0e123f9c33ea9787919799fdcacd4a2f2467c4d1/R/05makeBibLatex.R#L764

https://github.com/ropensci/RefManageR/blob/0e123f9c33ea9787919799fdcacd4a2f2467c4d1/R/05makeBibLatex.R#L789

You can reproduce this bug with the following snippet:

```r
test <- bibentry("phdthesis", key = "test00", title = "test", author = "test", school = "test", year = "2018")

Cite(test, "test00")

PrintBibliography(test, .opts = list(bib.style = "authoryear"))
```

~~I didn't test this locally yet. I will try later.~~ I just tested this fix on the provided reproducible example and it seems to fix the issue.